### PR TITLE
Account for `git rebase <branch> -X theirs` failing, prevent globbing and word splitting, apply standard formatter

### DIFF
--- a/git-rebase-via-merge.sh
+++ b/git-rebase-via-merge.sh
@@ -6,7 +6,7 @@
 # Copyright (c) 2022 Baur Atanov
 #
 
-default_base_branch="origin/main"
+default_base_branch="origin/develop"
 base_branch=${1:-$default_base_branch}
 set -e
 
@@ -113,7 +113,7 @@ init() {
 
   while true; do
     echo "Continue (c) / Abort (a)"
-    read -r input
+    read input
     echo
 
     if [ "$input" = "c" ]; then
@@ -169,7 +169,7 @@ fix_merge_conflicts() {
     echo
 
     echo "Continue (c) / Abort (a)"
-    read -r input
+    read input
     echo
 
     if [ "$input" = "c" ]; then
@@ -206,7 +206,7 @@ fix_rebase_conflicts() {
     echo
 
     echo "Continue (c) / Abort (a)"
-    read -r input
+    read input
     echo
 
     if [ "$input" = "c" ]; then

--- a/git-rebase-via-merge.sh
+++ b/git-rebase-via-merge.sh
@@ -6,19 +6,18 @@
 # Copyright (c) 2022 Baur Atanov
 #
 
-default_base_branch="origin/develop"
+default_base_branch="origin/main"
 base_branch=${1:-$default_base_branch}
 set -e
 
-
-main(){
+main() {
   echo "This script will perform rebase via merge."
   echo
 
   init
 
-  git checkout --quiet $current_branch_hash # switching to detached head state (no current branch)
-  git merge $base_branch -m "Hidden orphaned commit to save merge result." || true
+  git checkout --quiet "$current_branch_hash" # switching to detached head state (no current branch)
+  git merge "$base_branch" -m "Hidden orphaned commit to save merge result." || true
   echo
 
   if merge_conflicts_present; then
@@ -26,21 +25,26 @@ main(){
     echo
     fix_merge_conflicts
   fi
-  
+
   hidden_result_hash=$(get_hash HEAD)
 
   echo "Merge succeeded at hidden commit:"
-  echo $hidden_result_hash
+  echo "$hidden_result_hash"
   echo
 
   echo "Starting rebase resolving any conflicts automatically."
 
-  git checkout --quiet $current_branch
-  git rebase $base_branch -X theirs
-  echo
+  git checkout --quiet "$current_branch"
+  git rebase "$base_branch" -X theirs || true
+
+  if rebase_conflicts_present; then
+    echo "You have at least one rebase conflict."
+    echo
+    fix_rebase_conflicts
+  fi
 
   current_tree=$(git cat-file -p HEAD | grep tree)
-  result_tree=$(git cat-file -p $hidden_result_hash | grep tree)
+  result_tree=$(git cat-file -p "$hidden_result_hash" | grep tree)
 
   if [ "$current_tree" != "$result_tree" ]; then
     echo "Restoring project state from the hidden merge with single additional commit."
@@ -49,7 +53,7 @@ main(){
     additional_commit_message="Rebase via merge. '$current_branch' rebased on '$base_branch'."
     additional_commit_hash=$(git commit-tree $hidden_result_hash^{tree} -p HEAD -m "$additional_commit_message")
 
-    git merge --ff $additional_commit_hash
+    git merge --ff "$additional_commit_hash"
     echo
   else
     echo "You don't need additional commit. Project state is correct."
@@ -59,8 +63,7 @@ main(){
   exit 0
 }
 
-
-init(){
+init() {
   current_branch=$(git symbolic-ref --short HEAD)
 
   if [ -z "$current_branch" ]; then
@@ -68,8 +71,8 @@ init(){
     exit 1
   fi
 
-  base_branch_hash=$(get_hash $base_branch)
-  current_branch_hash=$(get_hash $current_branch)
+  base_branch_hash=$(get_hash "$base_branch")
+  current_branch_hash=$(get_hash "$current_branch")
 
   if [ -z "$base_branch_hash" ]; then
     echo "Can't rebase. Base branch '$base_branch' not found."
@@ -78,12 +81,12 @@ init(){
 
   echo "Current branch:"
   echo "$current_branch ($current_branch_hash)"
-  echo $(show_commit $current_branch_hash)
+  show_commit "$current_branch_hash"
   echo
 
   echo "Base branch:"
   echo "$base_branch ($base_branch_hash)"
-  echo $(show_commit $base_branch_hash)
+  show_commit "$base_branch_hash"
   echo
 
   if [ -n "$(get_any_changed_files)" ]; then
@@ -98,20 +101,19 @@ init(){
     exit 1
   fi
 
-  if [ -z "$(git rev-list $base_branch ^$current_branch)" ]; then
+  if [ -z "$(git rev-list "$base_branch" ^"$current_branch")" ]; then
     echo "Can't rebase. Current branch is already rebased."
     exit 1
   fi
 
-  if [ -z "$(git rev-list ^$base_branch $current_branch)" ]; then
+  if [ -z "$(git rev-list ^"$base_branch" "$current_branch")" ]; then
     echo "Can't rebase. Current branch has no any unique commits. You can do fast-forward merge."
     exit 1
   fi
 
-  while true
-  do
+  while true; do
     echo "Continue (c) / Abort (a)"
-    read input
+    read -r input
     echo
 
     if [ "$input" = "c" ]; then
@@ -127,35 +129,47 @@ init(){
   done
 }
 
-get_any_changed_files(){
+get_any_changed_files() {
   git status --porcelain --ignore-submodules=dirty | cut -c4-
 }
 
-get_unstaged_files(){
+get_unstaged_files() {
   git status --porcelain --ignore-submodules=dirty | grep -v "^. " | cut -c4-
 }
 
-merge_conflicts_present(){
-  file_merge="$(git rev-parse --show-toplevel)/.git/MERGE_HEAD"
-  [ -e $file_merge ]
+get_files_with_conflict_markers() {
+  git diff --check | cat
 }
 
-get_hash(){
+merge_conflicts_present() {
+  file_merge="$(git rev-parse --show-toplevel)/.git/MERGE_HEAD"
+  [ -e "$file_merge" ]
+}
+
+rebase_conflicts_present() {
+  [[ $(git diff --name-only --diff-filter=U --relative) ]]
+}
+
+get_hash() {
   git rev-parse --short "$1" || true
 }
 
-show_commit(){
+show_commit() {
   git log -n 1 --pretty=format:"%<(20)%an | %<(14)%ar | %s" "$1"
 }
 
-fix_merge_conflicts(){
-  while true
-  do
+fix_merge_conflicts() {
+  while true; do
     echo "Fix all conflicts in the following files, stage all the changes and type 'c':"
     get_unstaged_files
+    echo
+
+    echo "List of conflict markers:"
+    get_files_with_conflict_markers
+    echo
 
     echo "Continue (c) / Abort (a)"
-    read input
+    read -r input
     echo
 
     if [ "$input" = "c" ]; then
@@ -168,15 +182,52 @@ fix_merge_conflicts(){
         echo
       fi
     elif [ "$input" = "a" ]; then
-        echo "Aborting merge."
-        git merge --abort
-        git checkout $current_branch
-        echo "Aborted."
-        exit 2
+      echo "Aborting merge."
+      git merge --abort
+      git checkout "$current_branch"
+      echo "Aborted."
+      exit 2
     else
-        echo "Invalid option."
-        echo "Type key 'c' - to Continue or 'a' - to Abort."
+      echo "Invalid option."
+      echo "Type key 'c' - to Continue or 'a' - to Abort."
+      echo
+    fi
+  done
+}
+
+fix_rebase_conflicts() {
+  while true; do
+    echo "Fix all conflicts in the following files, stage all the changes and type 'c':"
+    get_unstaged_files
+    echo
+
+    echo "List of conflict markers:"
+    get_files_with_conflict_markers
+    echo
+
+    echo "Continue (c) / Abort (a)"
+    read -r input
+    echo
+
+    if [ "$input" = "c" ]; then
+      if [ -z "$(get_unstaged_files)" ]; then
+        git rebase --continue
+        break
+      else
+        echo "There are still unstaged files."
+        get_unstaged_files
         echo
+      fi
+    elif [ "$input" = "a" ]; then
+      echo "Aborting rebase."
+      git rebase --abort
+      git checkout "$current_branch"
+      echo "Aborted."
+      exit 2
+    else
+      echo "Invalid option."
+      echo "Type key 'c' - to Continue or 'a' - to Abort."
+      echo
     fi
   done
 }


### PR DESCRIPTION
This PR makes three changes:

1. When running `git rebase <branch> -X theirs`, there are various circumstances (like multiple renamed files) that can cause the command to error and the entire script to exit. So I've added a `|| true` to the rebase command followed by a check for any potential rebase conflicts that need to be manually dealt with before continuing the script, similar to the existing `if merge_conflicts_present; then` and `fix_merge_conflicts` block.

2. I fixed some [shellcheck](https://github.com/koalaman/shellcheck) linter errors; the main one was [SC2086](https://www.shellcheck.net/wiki/SC2086)
    - `echo $some_var` becomes `echo "$some_var"`

3. I applied https://github.com/mvdan/sh#shfmt to the entire script.

I've tested the changes on several very large and gnarly PRs with dozens of conflicted files at a time. 😄 